### PR TITLE
refactor(*): move to es6, add typings

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+/*
+!/lib
+!/typings.d.ts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
+  - "6"
+  - "8"
 git:
   depth: 10
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
 git:
   depth: 10

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/limitus');

--- a/lib/limitus.js
+++ b/lib/limitus.js
@@ -95,7 +95,7 @@ class Limitus {
             // If we exceeded the limit and we don't want to
             // overflow, return the rejection at this point.
             if (data.limited && !this._overflows) {
-                return callback(new Rejected(), data);
+                return callback(new Rejected(data.info), data);
             }
             return callback(undefined, data);
         });
@@ -143,7 +143,7 @@ class Limitus {
                 // At this point, throw a rejected error or
                 // resolve the promise and move on.
                 if (data.limited) {
-                    callback(new Rejected(), data.info);
+                    callback(new Rejected(data.info), data.info);
                 } else {
                     callback(undefined, data.info);
                 }

--- a/lib/limitus.js
+++ b/lib/limitus.js
@@ -1,54 +1,9 @@
-var Bluebird = require('bluebird');
-var Rejected = require('./rejected');
-var modes = require('./modes');
-var util = require('./util');
+'use strict';
 
-function Limitus (options) {
-    options = options || {};
-    this._overflows = !!options.overflow;
-
-    this._objStore = {};
-    this._rules = {};
-
-    this._cleanInterval = options.cleanInterval || 5000;
-    this._cleaning = false;
-}
-
-/**
- * Overrides a Limitus instance's values with that of another object.
- * @param  {Object} obj
- * @return {Limitus}
- */
-Limitus.prototype.extend = function (obj) {
-    for (var key in obj) {
-        this[key] = obj[key];
-    }
-
-    return this;
-};
-
-/**
- * Creates a new limitus rule in advance, and binds an alias.
- * @param  {String} name
- * @param  {Object} rule
- * @return {Limitus}
- */
-Limitus.prototype.rule = function (name, rule) {
-    this._rules[name] = rule;
-    this[util.camel('drop ' + name)] = this.drop.bind(this, name);
-
-    return this;
-};
-
-/**
- * Converts an identifier into a key for storage.
- * @param  {String} name rule name
- * @param  {Object} ident
- * @return {String}
- */
-Limitus.prototype.identToKey = function (name, ident) {
-    return String(name + ':' + util.hash(JSON.stringify(ident)));
-};
+const Rejected = require('./rejected');
+const modes = require('./modes');
+const util = require('./util');
+const { promisify } = require('util');
 
 /**
  * Wraps a function to correctly resolve its rule and callback.
@@ -67,13 +22,182 @@ function loadArgs (fn) {
         // Load the rule of none was given.
         rule = rule || this._rules[name];
         if (!rule) {
-            var err = new Error('Rule for ' + name + ' not defined.');
-            return callback ? callback(err) : Bluebird.reject(err);
+            const err = new Error('Rule for ' + name + ' not defined.');
+            return callback ? callback(err) : Promise.reject(err);
         }
 
-        return fn(this, name, ident, rule, callback);
+        return fn.call(this, name, ident, rule, callback);
     };
 };
+
+class Limitus {
+    constructor (options) {
+        options = options || {};
+        this._overflows = !!options.overflow;
+
+        this._objStore = {};
+        this._rules = {};
+
+        this._cleanInterval = options.cleanInterval || 5000;
+        this._cleaning = false;
+    }
+    /**
+     * Overrides a Limitus instance's values with that of another object.
+     * @param  {Object} obj
+     * @return {Limitus}
+     */
+    extend (obj) {
+        for (let key in obj) {
+            this[key] = obj[key];
+        }
+
+        return this;
+    }
+
+    /**
+     * Creates a new limitus rule in advance, and binds an alias.
+     * @param  {String} name
+     * @param  {Object} rule
+     * @return {Limitus}
+     */
+    rule (name, rule) {
+        this._rules[name] = rule;
+        this[util.camel('drop ' + name)] = this.drop.bind(this, name);
+
+        return this;
+    }
+
+    /**
+     * Converts an identifier into a key for storage.
+     * @param  {String} name rule name
+     * @param  {Object} ident
+     * @return {String}
+     */
+    identToKey (name, ident) {
+        return String(name + ':' + util.hash(JSON.stringify(ident)));
+    }
+    /**
+     * Base implementation of CheckLimited, for internal user.
+     * @param  {Object} rule
+     * @param  {Object}   mode
+     * @param  {Strign}   key
+     * @param  {Function} callback
+     * @return {Function}
+     */
+    baseCheckLimited (rule, key, callback) {
+        const mode = this.resolveMode(rule.mode);
+
+        // Pull up the data from the storage.
+        this.get(key, (err, value) => {
+            if (err) return callback(err);
+
+            const data = mode(rule, value);
+            // If we exceeded the limit and we don't want to
+            // overflow, return the rejection at this point.
+            if (data.limited && !this._overflows) {
+                return callback(new Rejected(), data);
+            }
+            return callback(undefined, data);
+        });
+    }
+
+    /**
+     * Returns the mode function for the rule. It is:
+     *   - Treated as "continuous" if not defined;
+     *   - Requires from "./modes/{mode}.js" if a string;
+     *   - Returned directly otherwise.
+     *
+     * @param  {*} mode
+     * @return {Function}
+     */
+    resolveMode (mode) {
+        mode = mode || 'continuous';
+
+        if (typeof mode === 'string') {
+            return modes[mode];
+        }
+        return mode;
+    }
+
+    /**
+     * Base, callback-based drop function.
+     * @param  {String}   name
+     * @param  {Object}   ident
+     * @param  {Object=}  rule
+     * @param  {Function} callback
+     * @return {Promise}
+     */
+    baseDrop (name, ident, rule, callback) {
+        const key = this.identToKey(name, ident);
+
+        this.baseCheckLimited(rule, key, (err, data) => {
+            if (err) {
+                return callback(err, data && data.info);
+            }
+
+            // Save the "next" limit in whatever store
+            // we're using.
+            this.set(key, data.next, data.expiration, (err) => {
+                if (err) return callback(err, data.info);
+
+                // At this point, throw a rejected error or
+                // resolve the promise and move on.
+                if (data.limited) {
+                    callback(new Rejected(), data.info);
+                } else {
+                    callback(undefined, data.info);
+                }
+            });
+        });
+    }
+
+    /**
+     * Function that scrubs out objstore occasionally to prevent
+     * memory leaks. Should only be used with the default implementation.
+     */
+    maintain () {
+        const oldStore = this._objStore;
+        const newStore = this._objStore = {};
+        const now = Date.now();
+
+        for (let key in oldStore) {
+            if (oldStore[key][1] > now) {
+                newStore[key] = oldStore[key];
+            }
+        }
+    };
+
+    /**
+     * Sets a key in some key/value store. Defaults to an internal, simple
+     * object store, but you probably want to use Redis or Memcached or
+     * something similar in production.
+     *
+     * @param {String}   key
+     * @param {String}   value
+     * @param {Number}   expiration Duration in milliseconds
+     * @param {Function} callback
+     */
+    set (key, value, expiration, callback) {
+        this._objStore[key] = [value, Date.now() + expiration];
+
+        if (!this._cleaning) {
+            this._cleaning = true;
+            setInterval(this.maintain.bind(this), this._cleanInterval);
+        }
+
+        callback();
+    };
+
+    /**
+     * Returns a value from the store, or undefined.
+     * @param  {String}   key
+     * @param  {Function} callback
+     */
+    get (key, callback) {
+        const value = this._objStore[key];
+        callback(undefined, value ? value[0] : undefined);
+    }
+}
 
 /**
  * Runs a limit. Returns a promise that is rejected if the user
@@ -85,14 +209,13 @@ function loadArgs (fn) {
  * @param  {Function} callback
  * @return {Promise}
  */
-Limitus.prototype.drop = loadArgs(function (self, name, ident, rule, callback) {
+Limitus.prototype.drop = loadArgs(function (name, ident, rule, callback) {
     // If we have a callback, pass it right in to baseDrop.
     // Otherwise, use the promisified version.
     if (callback) {
-        return self.baseDrop(name, ident, rule, callback);
-    } else {
-        return self.baseDropAsync(name, ident, rule);
+        return this.baseDrop(name, ident, rule, callback);
     }
+    return this.baseDropAsync(name, ident, rule);
 });
 
 /**
@@ -104,145 +227,18 @@ Limitus.prototype.drop = loadArgs(function (self, name, ident, rule, callback) {
  * @param  {Function} callback
  * @return {Boolean}
  */
-Limitus.prototype.checkLimited = loadArgs(function (self, name, ident, rule, callback) {
-    var mode = self.resolveMode(rule.mode);
-    var key = self.identToKey(name, ident);
+Limitus.prototype.checkLimited = loadArgs(function (name, ident, rule, callback) {
+    const mode = this.resolveMode(rule.mode);
+    const key = this.identToKey(name, ident);
 
     if (callback) {
-        return self.baseCheckLimited(rule, key, callback);
-    } else {
-        return self.baseCheckLimitedAsync(rule, key);
+        return this.baseCheckLimited(rule, key, callback);
     }
+   return this.baseCheckLimitedAsync(rule, key);
 });
 
-/**
- * Base implementation of CheckLimited, for internal user.
- * @param  {Object} rule
- * @param  {Object}   mode
- * @param  {Strign}   key
- * @param  {Function} callback
- * @return {Function}
- */
-Limitus.prototype.baseCheckLimited = function (rule, key, callback) {
-    var mode = this.resolveMode(rule.mode);
-    var self = this;
-
-    // Pull up the data from the storage.
-    self.get(key, function (err, value) {
-        if (err) return callback(err);
-
-        var data = mode(rule, value);
-        // If we exceeded the limit and we don't want to
-        // overflow, return the rejection at this point.
-        if (data.limited && !self._overflows) {
-            return callback(new Rejected(), data);
-        } else {
-            return callback(undefined, data);
-        }
-    });
-};
-Limitus.prototype.baseCheckLimitedAsync = Bluebird.promisify(Limitus.prototype.baseCheckLimited);
-
-/**
- * Returns the mode function for the rule. It is:
- *   - Treated as "continuous" if not defined;
- *   - Requires from "./modes/{mode}.js" if a string;
- *   - Returned directly otherwise.
- *
- * @param  {*} mode
- * @return {Function}
- */
-Limitus.prototype.resolveMode = function (mode) {
-    mode = mode || 'continuous';
-
-    if (typeof mode === 'string') {
-        return modes[mode];
-    } else {
-        return mode;
-    }
-};
-
-/**
- * Base, callback-based drop function.
- * @param  {String}   name
- * @param  {Object}   ident
- * @param  {Object=}  rule
- * @param  {Function} callback
- * @return {Promise}
- */
-Limitus.prototype.baseDrop = function (name, ident, rule, callback) {
-    var key = this.identToKey(name, ident);
-    var self = this;
-
-    self.baseCheckLimited(rule, key, function (err, data) {
-        if (err) {
-            return callback(err, data && data.info);
-        }
-
-        // Save the "next" limit in whatever store
-        // we're using.
-        self.set(key, data.next, data.expiration, function (err) {
-            if (err) return callback(err, data.info);
-
-            // At this point, throw a rejected error or
-            // resolve the promise and move on.
-            if (data.limited) {
-                callback(new Rejected(), data.info);
-            } else {
-                callback(undefined, data.info);
-            }
-        });
-    });
-};
-
-Limitus.prototype.baseDropAsync = Bluebird.promisify(Limitus.prototype.baseDrop);
-
-/**
- * Function that scrubs out objstore occasionally to prevent
- * memory leaks. Should only be used with the default implementation.
- */
-Limitus.prototype.maintain = function () {
-    var oldStore = this._objStore;
-    var newStore = this._objStore = {};
-    var now = Date.now();
-
-    for (var key in oldStore) {
-        if (oldStore[key][1] > now) {
-            newStore[key] = oldStore[key];
-        }
-    }
-};
-
-/**
- * Sets a key in some key/value store. Defaults to an internal, simple
- * object store, but you probably want to use Redis or Memcached or
- * something similar in production.
- *
- * @param {String}   key
- * @param {String}   value
- * @param {Number}   expiration Duration in milliseconds
- * @param {Function} callback
- */
-Limitus.prototype.set = function (key, value, expiration, callback) {
-    this._objStore[key] = [value, Date.now() + expiration];
-
-    if (!this._cleaning) {
-        this._cleaning = true;
-        setInterval(this.maintain.bind(this), this._cleanInterval);
-    }
-
-    callback();
-};
-
-/**
- * Returns a value from the store, or undefined.
- * @param  {String}   key
- * @param  {Function} callback
- */
-Limitus.prototype.get = function (key, callback) {
-    var value = this._objStore[key];
-    callback(undefined, value ? value[0] : undefined);
-};
+Limitus.prototype.baseCheckLimitedAsync = promisify(Limitus.prototype.baseCheckLimited);
+Limitus.prototype.baseDropAsync = promisify(Limitus.prototype.baseDrop);
 
 /**
  * The error that is thrown when we're over the rate limit.

--- a/lib/modes/continuous.js
+++ b/lib/modes/continuous.js
@@ -1,5 +1,5 @@
 function divide(str, substr) {
-    var idx = str.indexOf(substr);
+    const idx = str.indexOf(substr);
     return [str.slice(0, idx), str.slice(idx + 1)];
 }
 
@@ -16,12 +16,12 @@ function divide(str, substr) {
  * @return {Object}
  */
 module.exports = function (rule, value) {
-    var parts = divide(value || '0:0', ':');
-    var count = +parts[0];
-    var last = +parts[1];
+    const parts = divide(value || '0:0', ':');
+    let count = +parts[0];
+    let last = +parts[1];
 
     // time it takes to decrement one count
-    var unitTime = rule.interval / rule.max;
+    const unitTime = rule.interval / rule.max;
 
     count = Math.max(0, count - (Date.now() - last) / unitTime) + 1;
     last = Date.now();

--- a/lib/modes/interval.js
+++ b/lib/modes/interval.js
@@ -7,10 +7,10 @@
  * @return {Object}
  */
 module.exports = function (rule, value) {
-    var parts = (value || '0:0').split(':', 2);
-    var count = +parts[0];
-    var bucket = +parts[1];
-    var now = Date.now();
+    const parts = (value || '0:0').split(':', 2);
+    let count = +parts[0];
+    let bucket = +parts[1];
+    const now = Date.now();
 
     if (now >= bucket) {
         count = 0;

--- a/lib/rejected.js
+++ b/lib/rejected.js
@@ -1,11 +1,5 @@
-var util = require('util');
-
-
-function Rejected () {
-    Error.call(this);
-    this.message = 'Rate limit exceeded.';
+module.exports = class Rejected extends Error {
+    constructor() {
+        super('Rate limit exceeded.');
+    }
 }
-
-util.inherits(Rejected, Error);
-
-module.exports = Rejected;

--- a/lib/rejected.js
+++ b/lib/rejected.js
@@ -1,5 +1,6 @@
 module.exports = class Rejected extends Error {
-    constructor() {
+    constructor(info) {
         super('Rate limit exceeded.');
+        this.info = info;
     }
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,14 +1,12 @@
-var util = module.exports = {};
-
-var letter = /[a-z]/i;
+const letter = /[a-z]/i;
 
 /**
  * Fast djb2-like hashing implementation.
  * @param  {String} str
  * @return {Number}
  */
-util.hash = function (str) {
-    var hash = 5381, i = str.length;
+exports.hash = function (str) {
+    let hash = 5381, i = str.length;
 
     while (i) {
         hash = (hash * 33) ^ str.charCodeAt(--i);
@@ -22,10 +20,11 @@ util.hash = function (str) {
  * @param  {String} str
  * @return {String}
  */
-util.camel = function (str) {
-    var out = '', upper = false;
+exports.camel = function (str) {
+    let out = '';
+    let upper = false;
 
-    for (var i = 0; i < str.length; i++) {
+    for (let i = 0; i < str.length; i++) {
         if (letter.test(str[i])) {
             out += upper ? str[i].toUpperCase() : str[i];
             upper = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -64,11 +73,6 @@
         "platform": "1.3.5"
       }
     },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -78,6 +82,12 @@
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
     },
     "camelcase": {
       "version": "1.2.1",
@@ -98,15 +108,24 @@
       }
     },
     "chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
         "assertion-error": "1.1.0",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "cliui": {
       "version": "2.1.0",
@@ -130,9 +149,9 @@
       }
     },
     "commander": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "concat-map": {
@@ -142,12 +161,12 @@
       "dev": true
     },
     "debug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
-        "ms": "0.7.1"
+        "ms": "2.0.0"
       }
     },
     "decamelize": {
@@ -158,20 +177,12 @@
       "optional": true
     },
     "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "0.1.1"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-          "dev": true
-        }
+        "type-detect": "4.0.8"
       }
     },
     "deep-is": {
@@ -181,15 +192,15 @@
       "dev": true
     },
     "diff": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escodegen": {
@@ -229,14 +240,17 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "formatio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.1.2"
-      }
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "glob": {
       "version": "5.0.15",
@@ -252,9 +266,9 @@
       }
     },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "handlebars": {
@@ -286,6 +300,12 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -306,6 +326,12 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "isexe": {
@@ -336,30 +362,6 @@
         "wordwrap": "1.0.0"
       }
     },
-    "jade": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-      "dev": true,
-      "requires": {
-        "commander": "0.6.1",
-        "mkdirp": "0.3.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-          "dev": true
-        }
-      }
-    },
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
@@ -377,6 +379,12 @@
           "dev": true
         }
       }
+    },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
@@ -410,22 +418,22 @@
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lolex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
       "dev": true
     },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
     "minimatch": {
@@ -461,56 +469,72 @@
       }
     },
     "mocha": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
+      "integrity": "sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==",
       "dev": true,
       "requires": {
-        "commander": "2.3.0",
-        "debug": "2.2.0",
-        "diff": "1.4.0",
-        "escape-string-regexp": "1.0.2",
-        "glob": "3.2.11",
-        "growl": "1.9.2",
-        "jade": "0.26.3",
+        "browser-stdout": "1.3.1",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
         "mkdirp": "0.5.1",
-        "supports-color": "1.2.0",
-        "to-iso-string": "0.0.2"
+        "supports-color": "4.4.0"
       },
       "dependencies": {
         "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
             "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          }
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
         },
         "supports-color": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
-          "dev": true
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
     "ms": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "nise": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.2.tgz",
+      "integrity": "sha512-KPKb+wvETBiwb4eTwtR/OsA2+iijXP+VnlSFYJo3EHjm2yjek1NWxHOUQat3i7xNLm1Bm18UA5j5Wor0yO2GtA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.3.2",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      }
     },
     "nopt": {
       "version": "3.0.6",
@@ -568,6 +592,21 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "platform": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
@@ -603,27 +642,41 @@
       }
     },
     "samsam": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
-      "dev": true
-    },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "sinon": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.9.tgz",
+      "integrity": "sha512-0T0jXEG897qaZF4I9YHmqQIM7g48I62EQiM/2J1J6C5pIYBFpk8YAECSE/gmXIxLU5xVT3qqsQto2VSByrHXlg==",
       "dev": true,
       "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": "0.10.3"
+        "@sinonjs/formatio": "2.0.0",
+        "diff": "3.5.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.2",
+        "nise": "1.3.2",
+        "supports-color": "5.3.0",
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "source-map": {
@@ -651,10 +704,10 @@
         "has-flag": "1.0.0"
       }
     },
-    "to-iso-string": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
     "type-check": {
@@ -667,9 +720,9 @@
       }
     },
     "type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "uglify-js": {
@@ -699,23 +752,6 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
-    },
-    "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        }
-      }
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "limitus",
   "version": "2.2.2",
   "description": "Limitus makes rate limiting your anything a snap.",
-  "main": "index.js",
+  "main": "lib/limitus.js",
+  "typings": "typings.d.ts",
   "scripts": {
     "test": "node node_modules/mocha/bin/mocha test --recursive",
     "cover": "node node_modules/istanbul/lib/cli cover node_modules/mocha/bin/_mocha -- test --recursive",
@@ -10,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MCProHosting/limitus.git"
+    "url": "https://github.com/Mixer/limitus.git"
   },
   "keywords": [
     "rate",
@@ -20,17 +21,14 @@
   "author": "Connor Peet <connor@peet.io>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/MCProHosting/limitus/issues"
+    "url": "https://github.com/Mixer/limitus/issues"
   },
-  "homepage": "https://github.com/MCProHosting/limitus",
+  "homepage": "https://github.com/Mixer/limitus",
   "devDependencies": {
     "benchmark": "^2.1.0",
-    "chai": "^3.5.0",
+    "chai": "^4.1.2",
     "istanbul": "^0.4.2",
-    "mocha": "^2.4.5",
-    "sinon": "^1.17.3"
-  },
-  "dependencies": {
-    "bluebird": "^3.3.1"
+    "mocha": "^5.0.5",
+    "sinon": "^4.4.9"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,14 @@
 # Limitus
 
-[![Build Status](https://travis-ci.org/mixer/limitus.svg)](https://travis-ci.org/MCProHosting/limitus) [![Coverage Status](https://coveralls.io/repos/mixer/limitus/badge.svg?branch=master)](https://coveralls.io/r/mixer/limitus?branch=master)
+[![Build Status](https://travis-ci.org/mixer/limitus.svg)](https://travis-ci.org/Mixer/limitus) [![Coverage Status](https://coveralls.io/repos/mixer/limitus/badge.svg?branch=master)](https://coveralls.io/r/mixer/limitus?branch=master)
 
 Limitus is a (very) fast solution to rate limiting your application. It is agnostic as far as persistence goes - all you need to run it is a key value store (see examples for implementations using a plain hashmap and Redis).
 
 ## Example
 
 ```js
-var Limitus = require('limitus');
-var limiter = new Limitus();
+const Limitus = require('limitus');
+const limiter = new Limitus();
 
 /* create a "login" bucket */
 limiter.rule('login', { max: 5, interval: 1000 * 60 * 5 });

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,36 +1,43 @@
 declare namespace Limitus {
     export interface LimitusExtendOptions {
-    get(key: string, callback: (err: Error, value?: string) => void): void;
-    set(key: string, value: string, expiration?: number, callback?: (err?: Error) => void): void;
+        get(key: string, callback: (err: Error, value?: string) => void): void;
+        set(key: string, value: string, expiration?: number, callback?: (err?: Error) => void): void;
     }
 
     export interface DropInfo {
-    count: number;
-    bucket: number;
+        count: number;
+        bucket: number;
     }
 
     export interface ModeResult {
-    limited: boolean;
-    next: string;
-    expiration: number;
-    info?: DropInfo;
+        limited: boolean;
+        next: string;
+        expiration: number;
+        info?: DropInfo;
     }
 
     export type ModeFn = (rule: Rule, value: string) => ModeResult;
 
     export interface Rule {
-    max: number;
-    interval: number;
-    mode?: 'continuous' | 'interval' | ModeFn;
+        max: number;
+        interval: number;
+        mode?: 'continuous' | 'interval' | ModeFn;
     }
 
     export class Rejected extends Error {
-
+        public readonly info: DropInfo;
     }
+
+    export type Ident = object | string | number;
 }
 declare class Limitus {
     public extend(obj: Limitus.LimitusExtendOptions): this;
     public rule(name: string, rule: Limitus.Rule): this;
-    public drop(name: string, ident: object, rule?: Limitus.Rule)
+
+
+    public drop(name: string, ident: Limitus.Ident, rule?: Limitus.Rule): Promise<Limitus.ModeResult>;
+    public drop(name: string, ident: Limitus.Ident, rule?: Limitus.Rule, callback?: (err: Error | null, res?: Limitus.ModeResult) => void): void;
+    public checkLimited(name: string, ident: Limitus.Ident, rule?: Limitus.Rule): Promise<Limitus.ModeResult>;
+    public checkLimited(name: string, ident: Limitus.Ident, rule?: Limitus.Rule, callback?: (err: Error | null, res?: Limitus.ModeResult) => void): void;
 }
 export = Limitus;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,36 @@
+declare namespace Limitus {
+    export interface LimitusExtendOptions {
+    get(key: string, callback: (err: Error, value?: string) => void): void;
+    set(key: string, value: string, expiration?: number, callback?: (err?: Error) => void): void;
+    }
+
+    export interface DropInfo {
+    count: number;
+    bucket: number;
+    }
+
+    export interface ModeResult {
+    limited: boolean;
+    next: string;
+    expiration: number;
+    info?: DropInfo;
+    }
+
+    export type ModeFn = (rule: Rule, value: string) => ModeResult;
+
+    export interface Rule {
+    max: number;
+    interval: number;
+    mode?: 'continuous' | 'interval' | ModeFn;
+    }
+
+    export class Rejected extends Error {
+
+    }
+}
+declare class Limitus {
+    public extend(obj: Limitus.LimitusExtendOptions): this;
+    public rule(name: string, rule: Limitus.Rule): this;
+    public drop(name: string, ident: object, rule?: Limitus.Rule)
+}
+export = Limitus;


### PR DESCRIPTION
This moves a few things to es6 without doing a full featured refactor.
Removes bluebird (yay I guess).
Also adds typings for good measure.